### PR TITLE
Fix a private-in-public error

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -22,7 +22,7 @@ pub trait ShuffledIterGen<T>: Rng {
 }
 
 #[derive(Copy, Clone)]
-struct Slice<'a, T: 'a> {
+pub struct Slice<'a, T: 'a> {
     iter: SI,
     slice: &'a [T],
 }


### PR DESCRIPTION
Not sure if this crate is abandoned or not, but it was broken by a bugfix in rustc (see https://tools.taskcluster.net/task-inspector/#5qPURD0TQ5qFbideErYOEQ/0 and rust-lang/rust#34537 for more details).
Here's a fix.
